### PR TITLE
Phase 1: releases and discoverability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ main, chore/** ]
+    branches: [ main ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -42,6 +43,7 @@ jobs:
         run: ./gradlew assembleDebug
 
       - name: Build release bundle
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
         run: ./gradlew bundleRelease
 
       - name: Publicar informes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,3 +55,36 @@ jobs:
             **/build/reports/lint-results-*.html
             **/build/reports/tests/
           retention-days: 7
+
+  release:
+    name: Publicar release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Preparar notas de la release
+        run: |
+          VERSION_CODE=$(grep -oE 'versionCode = [0-9]+' app/build.gradle.kts | grep -oE '[0-9]+')
+          CHANGELOG_DIR=fastlane/metadata/android/en-US/changelogs
+          if [ -f "$CHANGELOG_DIR/$VERSION_CODE.txt" ]; then
+            NOTES_FILE="$CHANGELOG_DIR/$VERSION_CODE.txt"
+          else
+            NOTES_FILE="$CHANGELOG_DIR/default.txt"
+          fi
+          echo "versionCode $VERSION_CODE, notas desde $NOTES_FILE"
+          cp "$NOTES_FILE" release-notes.md
+
+      - name: Crear la release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            --generate-notes

--- a/README.md
+++ b/README.md
@@ -9,8 +9,20 @@
 </p>
 
 <p align="center">
+  <a href="https://play.google.com/store/apps/details?id=com.jbgsoft.ambio">
+    <img src="https://img.shields.io/badge/Google%20Play-Download-414141?logo=googleplay&logoColor=white" alt="Get it on Google Play">
+  </a>
+  <a href="https://github.com/jaimebg/Ambio/releases/latest">
+    <img src="https://img.shields.io/github/v/release/jaimebg/Ambio?label=release&color=3DDC84" alt="Latest release">
+  </a>
+  <a href="https://github.com/jaimebg/Ambio/actions/workflows/ci.yml">
+    <img src="https://github.com/jaimebg/Ambio/actions/workflows/ci.yml/badge.svg" alt="CI">
+  </a>
+</p>
+
+<p align="center">
   <img src="https://img.shields.io/badge/Android-12%2B-3DDC84?logo=android&logoColor=white" alt="Android 12+">
-  <img src="https://img.shields.io/badge/Kotlin-2.0-7F52FF?logo=kotlin&logoColor=white" alt="Kotlin 2.0">
+  <img src="https://img.shields.io/badge/Kotlin-2.3-7F52FF?logo=kotlin&logoColor=white" alt="Kotlin 2.3">
   <img src="https://img.shields.io/badge/Jetpack%20Compose-UI-4285F4?logo=jetpackcompose&logoColor=white" alt="Jetpack Compose">
   <img src="https://img.shields.io/badge/Material%20Design%203-darkblue" alt="Material Design 3">
   <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
@@ -86,7 +98,7 @@ ui/            # Theme system, typography, shapes
 
 - Android 12+ (API 31)
 - Java 17
-- Android Studio Ladybug or newer
+- Android Studio Otter or newer (AGP 9 requires it)
 
 ## Getting Started
 
@@ -115,7 +127,7 @@ ui/            # Theme system, typography, shapes
 ```bash
 ./gradlew assembleDebug   # Build debug APK
 ./gradlew lint            # Run lint checks
-./gradlew test            # Run unit tests (75 tests)
+./gradlew test            # Run unit tests (154: 77 tests × debug and release variants)
 ./gradlew clean           # Clean build cache
 ```
 

--- a/docs/superpowers/plans/2026-08-03-phase-1-releases-discoverability.md
+++ b/docs/superpowers/plans/2026-08-03-phase-1-releases-discoverability.md
@@ -1,0 +1,506 @@
+# Fase 1 — Releases y descubribilidad: Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Que Ambio tenga historial de versiones navegable, releases que se publican solas desde el changelog que ya alimenta la ficha de Play, y un README que diga en qué versión va y cómo instalarla — sin secretos y sin pasos manuales recurrentes.
+
+**Architecture:** Todo vive en `.github/workflows/ci.yml` y `README.md`. El job de release se añade al workflow existente con `needs: build`, de modo que ninguna Release pueda publicarse sin haber pasado antes lint, tests, `assembleDebug` y `bundleRelease`. Las notas salen de `fastlane/metadata/android/en-US/changelogs/`, la misma fuente que usa Fastlane para Play.
+
+**Tech Stack:** GitHub Actions, `gh` CLI, shields.io, Fastlane metadata.
+
+**Spec:** `docs/superpowers/specs/2026-08-03-releases-and-discoverability-design.md`
+
+## Global Constraints
+
+- **Ningún secreto nuevo en GitHub Actions.** El proyecto usa Play App Signing y el dueño no
+  quiere claves de firma en CI. Ninguna tarea puede requerir un secret.
+- **No se adjuntan APKs ni AABs** a las releases, por la restricción de firma anterior.
+- **No se toca código de la app.** Esta fase sólo modifica `.github/workflows/ci.yml`,
+  `README.md`, y crea un tag. Ningún fichero bajo `app/`, `core/`, `feature/`, `media/`,
+  `ui/` o `build-logic/`.
+- **No se corta una release nueva.** El proyecto se queda en `versionCode 2` /
+  `versionName 1.1.0`. Publicar la Fase 0 es una decisión de producto aparte.
+- El job `build` conserva `permissions: contents: read`; sólo el job `release` obtiene
+  `contents: write`, a nivel de job.
+- Rama de trabajo: `chore/phase-1-releases-discoverability` (ya creada, contiene el spec).
+
+## File Structure
+
+| Fichero | Responsabilidad | Tarea |
+|---|---|---|
+| `.github/workflows/ci.yml` | Disparadores y coste del CI | 1 |
+| `.github/workflows/ci.yml` | Job `release`, gatillado por tags | 2 |
+| tag `v1.1.0` + su Release | Historial retroactivo | 3 |
+| `README.md` | Badges, enlace de instalación, datos desactualizados | 4 |
+
+---
+
+### Task 1: Disparadores del CI y coste
+
+Dos problemas medidos en la Fase 0: cada push a una rama con PR abierta dispara el workflow
+**dos veces** sobre el mismo commit (23 min de runner para 11 de información), y
+`bundleRelease` —el paso más caro, 4m 38s, más que el lint— se ejecuta en cada PR aunque
+sólo importe antes de publicar.
+
+**Files:**
+- Modify: `.github/workflows/ci.yml:3-8` (bloque `on:`)
+- Modify: `.github/workflows/ci.yml:44-45` (paso `Build release bundle`)
+
+**Interfaces:**
+- Consumes: nada.
+- Produces: el disparador `tags: [ 'v*' ]`, del que depende el job `release` de la Tarea 2.
+
+- [ ] **Step 1: Sustituir el bloque de disparadores**
+
+En `.github/workflows/ci.yml`, reemplazar las líneas 3-8 por:
+
+```yaml
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+```
+
+Sale `chore/**` del `push`: las ramas de trabajo reciben CI a través de su PR, no por
+partida doble. Entra `tags: [ 'v*' ]`, que es lo que la Tarea 2 necesita.
+
+- [ ] **Step 2: Condicionar `bundleRelease`**
+
+Reemplazar el paso `Build release bundle` por:
+
+```yaml
+      - name: Build release bundle
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        run: ./gradlew bundleRelease
+```
+
+**No borres ningún paso.** `assembleDebug` se queda: cuesta 2m 15s y no es redundante con
+`bundleRelease` — cubre las dependencias `debugImplementation` (el `compose.ui.tooling` de
+tres módulos), el merge de manifiestos y recursos de debug y el empaquetado, y es el comando
+que ejecuta cualquier contribuidor y que documenta `CLAUDE.md`.
+
+- [ ] **Step 3: Validar la sintaxis del YAML**
+
+```bash
+python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/ci.yml')); print('YAML valido')"
+```
+
+Esperado: `YAML valido`.
+
+- [ ] **Step 4: Commit y push**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: stop duplicate runs and gate the release bundle
+
+Pushes to a branch with an open PR triggered the workflow twice over the
+same commit. Branch work now gets CI through its PR. bundleRelease is the
+most expensive step at 4m38s and only matters before publishing, so it now
+runs on main and tags only."
+git push
+```
+
+- [ ] **Step 5: Verificar el comportamiento real de los disparadores**
+
+Este paso es el que da valor a la tarea: hay que **observar** que el doble run desapareció.
+
+```bash
+gh pr create --fill --base main 2>/dev/null || echo "(PR ya existe)"
+gh run list --branch chore/phase-1-releases-discoverability --limit 5 \
+  --json event,headSha,status --jq '.[] | "\(.event) \(.headSha[0:7]) \(.status)"'
+```
+
+Esperado: para el commit recién empujado aparece **un solo run**, con `event: pull_request`.
+Si aparecen dos (uno `push` y otro `pull_request`), el cambio de disparadores no surtió
+efecto — investigar antes de continuar.
+
+Esperar a que termine y comprobar que `bundleRelease` fue omitido:
+
+```bash
+gh run watch $(gh run list --branch chore/phase-1-releases-discoverability --limit 1 --json databaseId --jq '.[0].databaseId')
+gh api "repos/jaimebg/Ambio/actions/runs/$(gh run list --branch chore/phase-1-releases-discoverability --limit 1 --json databaseId --jq '.[0].databaseId')/jobs" \
+  --jq '.jobs[0].steps[] | "\(.name): \(.conclusion)"'
+```
+
+Esperado: el paso `Build release bundle` aparece con conclusión `skipped`, y `Lint`,
+`Tests unitarios` y `Build debug` con `success`.
+
+---
+
+### Task 2: Job de release
+
+**Files:**
+- Modify: `.github/workflows/ci.yml` (añadir un segundo job tras el job `build`)
+
+**Interfaces:**
+- Consumes: el disparador `tags: [ 'v*' ]` de la Tarea 1.
+- Produces: la automatización que la Tarea 3 deja documentada pero no usa (el tag
+  retroactivo apunta a un commit sin workflow).
+
+- [ ] **Step 1: Añadir el job `release`**
+
+Al final de `.github/workflows/ci.yml`, después del paso `Publicar informes` del job
+`build`, añadir un segundo job al mismo nivel de indentación que `build:`:
+
+```yaml
+
+  release:
+    name: Publicar release
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Preparar notas de la release
+        run: |
+          VERSION_CODE=$(grep -oE 'versionCode = [0-9]+' app/build.gradle.kts | grep -oE '[0-9]+')
+          CHANGELOG_DIR=fastlane/metadata/android/en-US/changelogs
+          if [ -f "$CHANGELOG_DIR/$VERSION_CODE.txt" ]; then
+            NOTES_FILE="$CHANGELOG_DIR/$VERSION_CODE.txt"
+          else
+            NOTES_FILE="$CHANGELOG_DIR/default.txt"
+          fi
+          echo "versionCode $VERSION_CODE, notas desde $NOTES_FILE"
+          cp "$NOTES_FILE" release-notes.md
+
+      - name: Crear la release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes-file release-notes.md \
+            --generate-notes
+```
+
+Tres cosas deliberadas:
+
+- **`needs: build`** es lo que garantiza que ninguna Release exista sin haber pasado lint,
+  tests, `assembleDebug` y `bundleRelease`. En un workflow separado, ambos se dispararían en
+  paralelo con el mismo tag y la Release podría publicarse mientras el build falla.
+- **Los permisos van en el job**, no en el workflow. El bloque `permissions: contents: read`
+  de nivel workflow sigue aplicando a `build`; sólo `release` obtiene escritura.
+- **`--generate-notes` junto a `--notes-file`** hace que GitHub añada la lista de cambios
+  autogenerada debajo del texto del changelog. Si al verificar resultara que `gh` ignora uno
+  de los dos, construir el cuerpo a mano concatenando ambos y decirlo en el informe.
+
+- [ ] **Step 2: Validar la sintaxis y la estructura de jobs**
+
+```bash
+python3 -c "
+import yaml
+w = yaml.safe_load(open('.github/workflows/ci.yml'))
+jobs = w['jobs']
+assert set(jobs) == {'build', 'release'}, jobs
+assert jobs['release']['needs'] == 'build'
+assert jobs['release']['permissions'] == {'contents': 'write'}
+assert w['permissions'] == {'contents': 'read'}
+print('estructura correcta')
+"
+```
+
+Esperado: `estructura correcta`.
+
+- [ ] **Step 3: Comprobar que el extractor de versionCode funciona**
+
+El job depende de sacar el `versionCode` con `grep`. Verificarlo contra el fichero real
+antes de confiar en él:
+
+```bash
+grep -oE 'versionCode = [0-9]+' app/build.gradle.kts | grep -oE '[0-9]+'
+```
+
+Esperado: `2`, y **una sola línea**. Si salen varias, el `grep` es ambiguo y hay que
+afinarlo antes de seguir.
+
+Y que el fichero de notas existe:
+
+```bash
+ls fastlane/metadata/android/en-US/changelogs/
+cat fastlane/metadata/android/en-US/changelogs/default.txt
+```
+
+Esperado: existe `default.txt` con las cuatro líneas del changelog de 1.1.0.
+
+- [ ] **Step 4: Commit y push**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: publish a GitHub Release when a version tag is pushed
+
+Release notes come from the Fastlane changelog, the same source that feeds
+the Play Store listing, so the two cannot drift. needs: build means no
+release can exist without lint, tests and both builds passing first."
+git push
+```
+
+- [ ] **Step 5: Verificar que el job no se activa fuera de tags**
+
+```bash
+gh run watch $(gh run list --branch chore/phase-1-releases-discoverability --limit 1 --json databaseId --jq '.[0].databaseId')
+gh api "repos/jaimebg/Ambio/actions/runs/$(gh run list --branch chore/phase-1-releases-discoverability --limit 1 --json databaseId --jq '.[0].databaseId')/jobs" \
+  --jq '.jobs[] | "\(.name): \(.conclusion)"'
+```
+
+Esperado: aparece únicamente el job `Lint, test y build`. El job `Publicar release` **no
+debe aparecer**, porque este push no es un tag. Si aparece, la condición `if` está mal.
+
+- [ ] **Step 6: Probar la automatización de verdad, con un tag desechable**
+
+Sin este paso, la automatización no se ejercita hasta la próxima release real — y si algo
+está mal, se descubriría en el peor momento. Se prueba con un tag temporal que luego se
+borra.
+
+**Aviso:** esto crea brevemente una Release pública en el repositorio. Se borra en el mismo
+paso. Si prefieres no hacerlo sobre el repo público, dilo y lo verificamos de otra forma.
+
+```bash
+git tag -a v0.0.1-ci-test -m "Prueba de la automatización de releases"
+git push origin v0.0.1-ci-test
+```
+
+Esperar a que termine el workflow del tag:
+
+```bash
+sleep 30
+RUN=$(gh run list --limit 10 --json databaseId,headBranch --jq '[.[] | select(.headBranch=="v0.0.1-ci-test")][0].databaseId')
+gh run watch "$RUN"
+gh api "repos/jaimebg/Ambio/actions/runs/$RUN/jobs" --jq '.jobs[] | "\(.name): \(.conclusion)"'
+```
+
+Esperado: **dos** jobs, `Lint, test y build` y `Publicar release`, ambos `success`. Y dentro
+del primero, el paso `Build release bundle` debe haberse **ejecutado** (no `skipped`), porque
+el ref es un tag.
+
+Comprobar el contenido de la Release generada:
+
+```bash
+gh release view v0.0.1-ci-test --json body --jq .body
+```
+
+Esperado: el cuerpo contiene las cuatro líneas del changelog de `default.txt` **y** una
+sección de cambios autogenerada por GitHub. Si sólo aparece una de las dos, `gh` no está
+combinando `--notes-file` con `--generate-notes`: construir el cuerpo a mano concatenando
+ambos, y dejarlo dicho en el informe.
+
+- [ ] **Step 7: Limpiar el tag de prueba**
+
+```bash
+gh release delete v0.0.1-ci-test --yes
+git push --delete origin v0.0.1-ci-test
+git tag -d v0.0.1-ci-test
+```
+
+Verificar que no queda rastro:
+
+```bash
+gh release list
+git tag
+git ls-remote --tags origin
+```
+
+Esperado: no aparece `v0.0.1-ci-test` en ninguno de los tres. En este punto de la fase, `git
+tag` puede estar vacío si la Tarea 3 aún no se ha hecho, o mostrar sólo `v1.1.0` si ya se
+hizo — ambas cosas son correctas.
+
+---
+
+### Task 3: Tag y Release retroactivos de v1.1.0
+
+**Files:**
+- Ninguno. Esta tarea crea un tag de git y una Release en GitHub.
+
+**Interfaces:**
+- Consumes: nada del repositorio de trabajo.
+- Produces: el tag `v1.1.0`, que hace que el badge de última release de la Tarea 4 tenga
+  algo que mostrar, y que las comparaciones de GitHub tengan un punto de partida.
+
+- [ ] **Step 1: Confirmar el commit objetivo**
+
+```bash
+git show --stat 4bc32a2 | head -8
+git show 4bc32a2:app/build.gradle.kts | grep -E "versionCode|versionName"
+```
+
+Esperado: el commit es `chore: release 1.1.0` del 2026-01-27, con `versionCode = 2` y
+`versionName = "1.1.0"`. Si no coincide, parar y reportar.
+
+- [ ] **Step 2: Crear el tag anotado y empujarlo**
+
+```bash
+git tag -a v1.1.0 4bc32a2 -m "Ambio 1.1.0"
+git push origin v1.1.0
+```
+
+**No crear `v1.0.0`.** Esa versión existió en el código pero nunca se publicó en Play;
+tagearla inventaría una release que no ocurrió.
+
+- [ ] **Step 3: Comprobar que el tag NO dispara el workflow**
+
+```bash
+sleep 20
+gh run list --limit 5 --json event,headBranch,status --jq '.[] | "\(.event) \(.headBranch) \(.status)"'
+```
+
+Esperado: **no aparece ningún run nuevo para `v1.1.0`**. Es lo correcto y esperado: GitHub
+ejecuta los workflows desde el commit tageado, y en `4bc32a2` todavía no existe
+`.github/workflows/ci.yml` — se creó en la Fase 0. Por eso esta Release se crea a mano.
+
+Si SÍ apareciera un run, algo no cuadra con esa premisa: parar y reportarlo.
+
+- [ ] **Step 4: Crear la Release a mano**
+
+```bash
+gh release create v1.1.0 \
+  --title "v1.1.0" \
+  --notes-file fastlane/metadata/android/en-US/changelogs/default.txt
+```
+
+`default.txt` es exactamente el changelog de la 1.1.0, así que es el texto correcto para
+esta Release. No se usa `--generate-notes` aquí: generaría la lista de todos los commits
+desde el inicio del proyecto.
+
+- [ ] **Step 5: Verificar**
+
+```bash
+gh release view v1.1.0 --json tagName,name,body,isDraft,isPrerelease \
+  --jq '"tag: \(.tagName)\ntitulo: \(.name)\nborrador: \(.isDraft), prerelease: \(.isPrerelease)\n---\n\(.body)"'
+git tag
+```
+
+Esperado: la Release existe, no es borrador ni prerelease, su cuerpo son las cuatro líneas
+del changelog, y `git tag` lista **únicamente** `v1.1.0`.
+
+---
+
+### Task 4: README — badges, instalación y datos desactualizados
+
+El README tiene cinco badges tecnológicos y ninguno que lleve a instalar la app ni que
+indique en qué versión va. Además, la Fase 0 invalidó dos afirmaciones que siguen ahí.
+
+**Files:**
+- Modify: `README.md:11-17` (bloque de badges)
+- Modify: `README.md` (sección `## Requirements`)
+- Modify: `README.md` (bloque `## Build Commands`)
+
+**Interfaces:**
+- Consumes: el tag `v1.1.0` de la Tarea 3, sin el cual el badge de release no muestra nada.
+- Produces: nada que consuman otras tareas.
+
+- [ ] **Step 1: Reemplazar el bloque de badges**
+
+Sustituir el bloque completo que hoy va de `<p align="center">` con los cinco badges
+`img.shields.io` (líneas 11-17) por:
+
+```html
+<p align="center">
+  <a href="https://play.google.com/store/apps/details?id=com.jbgsoft.ambio">
+    <img src="https://img.shields.io/badge/Google%20Play-Download-414141?logo=googleplay&logoColor=white" alt="Get it on Google Play">
+  </a>
+  <a href="https://github.com/jaimebg/Ambio/releases/latest">
+    <img src="https://img.shields.io/github/v/release/jaimebg/Ambio?label=release&color=3DDC84" alt="Latest release">
+  </a>
+  <a href="https://github.com/jaimebg/Ambio/actions/workflows/ci.yml">
+    <img src="https://github.com/jaimebg/Ambio/actions/workflows/ci.yml/badge.svg" alt="CI">
+  </a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/Android-12%2B-3DDC84?logo=android&logoColor=white" alt="Android 12+">
+  <img src="https://img.shields.io/badge/Kotlin-2.3-7F52FF?logo=kotlin&logoColor=white" alt="Kotlin 2.3">
+  <img src="https://img.shields.io/badge/Jetpack%20Compose-UI-4285F4?logo=jetpackcompose&logoColor=white" alt="Jetpack Compose">
+  <img src="https://img.shields.io/badge/Material%20Design%203-darkblue" alt="Material Design 3">
+  <img src="https://img.shields.io/badge/License-MIT-green" alt="MIT License">
+</p>
+```
+
+Dos filas a propósito: **arriba lo accionable** —instalar, ver la última versión, ver si el
+build está verde— y debajo lo informativo. El badge de Kotlin pasa de `2.0` a `2.3`, que es
+la versión real tras la Fase 0.
+
+- [ ] **Step 2: Corregir los datos que la Fase 0 invalidó**
+
+En la sección `## Requirements`, sustituir la línea de Android Studio:
+
+```
+- Android Studio Ladybug or newer
+```
+
+por:
+
+```
+- Android Studio Otter or newer (AGP 9 requires it)
+```
+
+En el bloque `## Build Commands`, la línea de tests dice `(75 tests)`. El número real tras
+la Fase 0 es 154 — son 77 métodos `@Test` ejecutados contra las variantes debug y release.
+Sustituirla por:
+
+```
+./gradlew test            # Run unit tests (154: 77 tests × debug and release variants)
+```
+
+- [ ] **Step 3: Verificar que no quedan datos obsoletos conocidos**
+
+```bash
+grep -nE "Kotlin-2\.0|75 tests|Ladybug" README.md && echo "QUEDAN OBSOLETOS" || echo "limpio"
+grep -nE "play.google.com|shields.io/github/v/release|actions/workflows/ci.yml/badge" README.md
+```
+
+Esperado: el primer comando imprime `limpio`. El segundo muestra las tres líneas de los
+badges nuevos.
+
+- [ ] **Step 4: Comprobar que los badges resuelven de verdad**
+
+Un badge roto es peor que ningún badge. Comprobar que las tres URLs devuelven contenido:
+
+```bash
+curl -sf -o /dev/null -w "play: %{http_code}\n" "https://img.shields.io/badge/Google%20Play-Download-414141?logo=googleplay&logoColor=white"
+curl -sf -o /dev/null -w "release: %{http_code}\n" "https://img.shields.io/github/v/release/jaimebg/Ambio?label=release&color=3DDC84"
+curl -sf -o /dev/null -w "ci: %{http_code}\n" "https://github.com/jaimebg/Ambio/actions/workflows/ci.yml/badge.svg"
+curl -sf -o /dev/null -w "play store: %{http_code}\n" "https://play.google.com/store/apps/details?id=com.jbgsoft.ambio"
+```
+
+Esperado: `200` en los cuatro. El badge de release sólo muestra `v1.1.0` si la Tarea 3 se
+completó; si devuelve 200 pero el SVG dice "no releases", revisar la Tarea 3.
+
+Si la URL de Play Store no devuelve 200, la app no está publicada bajo ese `applicationId`:
+parar y reportarlo en vez de dejar un enlace roto en la portada del proyecto.
+
+- [ ] **Step 5: Commit y push**
+
+```bash
+git add README.md
+git commit -m "docs: add install and release badges, refresh stale facts
+
+The README had five technology badges and nothing that let a visitor
+install the app or see which version the project is on. Also corrects two
+claims Phase 0 invalidated: the Kotlin badge and the unit test count."
+git push
+```
+
+---
+
+## Resultado esperado de la fase
+
+| | Antes | Después |
+|---|---|---|
+| Tags | ninguno | `v1.1.0` |
+| Releases | ninguna | 1, y las futuras se publican solas |
+| Fuente de las notas | — | el changelog que ya alimenta Play |
+| Runs por push con PR abierta | 2 | 1 |
+| Feedback en PR | ~11m 30s | ~7m |
+| `bundleRelease` | en cada PR | sólo en `main` y tags |
+| Badges de instalación y versión | ninguno | Play Store, última release, CI |
+
+Al terminar, la otra mitad de la fase original —`CONTRIBUTING.md`, plantillas de issue y PR,
+`CODE_OF_CONDUCT.md`— se puede montar sobre un proyecto que ya se puede encontrar, seguir e
+instalar.

--- a/docs/superpowers/specs/2026-08-03-releases-and-discoverability-design.md
+++ b/docs/superpowers/specs/2026-08-03-releases-and-discoverability-design.md
@@ -1,0 +1,192 @@
+# Fase 1 — Releases y descubribilidad
+
+**Fecha:** 2026-08-03
+**Estado:** Pendiente de aprobación
+
+## Contexto
+
+La Fase 0 dejó el toolchain moderno y un CI que valida cada cambio. Esta fase ataca un
+problema distinto, que el sondeo del repositorio destapó al empezar a diseñarla.
+
+Estado del proyecto al iniciar:
+
+| | |
+|---|---|
+| Tags de git | ninguno |
+| Releases publicadas | ninguna |
+| Issues (abiertas o cerradas) | ninguna |
+| Stars / forks | 0 / 0 |
+| Ficheros de comunidad | solo `LICENSE` |
+| README | 5 badges tecnológicos, ninguno de instalación ni de versión |
+
+**El proyecto no tiene audiencia.** No hay contribuidores cuya barrera bajar. Por eso esta
+fase invierte el orden que planteaba el roadmap original: antes que el papeleo de
+contribución va lo que hace que el proyecto se pueda encontrar y seguir. El papeleo
+(`CONTRIBUTING.md`, plantillas, `CODE_OF_CONDUCT.md`) queda para después.
+
+## Restricciones que definen el diseño
+
+**El proyecto usa Play App Signing** y el dueño no quiere claves de firma en GitHub
+Actions. Las dos cosas juntas descartan publicar APKs:
+
+- Sin clave en CI no hay artefacto firmable, y un APK firmado en debug no acredita nada:
+  cualquiera puede producir esa firma.
+- Con Play App Signing, el APK que reciben los usuarios lo firma Google con una clave que
+  el proyecto no posee. Cualquier APK que publicáramos tendría una firma distinta, y dos
+  APKs con firmas distintas no pueden actualizarse entre sí: quien instalara desde GitHub
+  quedaría en una rama de instalación separada y tendría que desinstalar —perdiendo sus
+  datos— para pasarse a la versión de Play.
+
+Se valoró y descartó adjuntar el APK universal firmado por Google que la Play Console
+permite descargar del *App Bundle Explorer* —que sí conservaría la compatibilidad de
+actualización— porque exige un paso manual en cada release. Esta fase se queda en lo
+totalmente automatizable.
+
+## Objetivos
+
+1. Que el repositorio tenga historial de versiones navegable.
+2. Que cada versión futura genere su Release sola, sin pasos manuales ni secretos.
+3. Que quien llegue al README vea en qué versión va el proyecto y cómo instalarlo.
+4. Que el CI deje de hacer trabajo duplicado y dé feedback más rápido en las PRs.
+
+## No objetivos
+
+- `CONTRIBUTING.md`, plantillas de issue/PR, `CODE_OF_CONDUCT.md`, `SECURITY.md`. Es la otra
+  mitad de la fase original; se hace cuando el proyecto ya se pueda encontrar.
+- Adjuntar APKs o AABs a las releases, por la restricción de firma de arriba.
+- F-Droid, que sigue en la Fase 4. Resolvería la instalación sin pasos manuales —compila
+  desde el código y firma con su propia clave— pero crea su propia rama de instalación,
+  distinta de Play, y es una decisión de distribución con entidad propia.
+- **Cortar una release nueva.** La Fase 0 cambió el binario entero (targetSdk 37 y todo el
+  toolchain) y el proyecto sigue en `versionCode 2` / `versionName 1.1.0`. Publicar eso es
+  una decisión de producto, no infraestructura.
+
+## Diseño
+
+### 1. Tag retroactivo `v1.1.0`
+
+Un único tag anotado sobre `4bc32a2` ("chore: release 1.1.0", 2026-01-27), que es el commit
+donde `versionCode` pasó a 2 y `versionName` a "1.1.0".
+
+**No se crea `v1.0.0`.** La versión 1.0.0 existió en el código —desde el commit inicial
+hasta `4bc32a2^`— pero nunca llegó a publicarse en Play. Tagearla inventaría una release
+que no ocurrió.
+
+**Su Release se crea a mano, y sólo ésta.** GitHub ejecuta los workflows desde el commit
+tageado, y en `4bc32a2` todavía no existe `.github/workflows/ci.yml` —se creó en la Fase 0—,
+así que empujar el tag no dispararía nada. La Release de `v1.1.0` se crea con
+`gh release create` en un paso único, con el texto de `changelogs/default.txt`, que es
+precisamente el changelog de esa versión. Todos los tags futuros salen del commit posterior
+a esta fase y sí activan la automatización.
+
+### 2. Job de release dentro de `ci.yml`
+
+El workflow existente gana un segundo job, `release`, que sólo se activa en tags:
+
+```yaml
+  release:
+    needs: build
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+```
+
+**El `needs: build` es la decisión importante.** Encadenar el release al job de build
+garantiza que ninguna Release pueda existir sin que antes hayan pasado lint, tests,
+`assembleDebug` y `bundleRelease`. Si se hiciera en un workflow separado, ambos se
+dispararían en paralelo con el mismo tag y la Release podría publicarse mientras el build
+falla.
+
+Los permisos van a nivel de job, no de workflow: el job `build` conserva
+`contents: read` y sólo `release` obtiene `contents: write`.
+
+El job:
+
+1. Lee `versionCode` de `app/build.gradle.kts`.
+2. Busca `fastlane/metadata/android/en-US/changelogs/<versionCode>.txt`; si no existe, usa
+   `changelogs/default.txt`.
+3. Crea la Release con ese texto como cuerpo, más la lista de cambios que GitHub genera
+   automáticamente desde el tag anterior.
+
+**Las notas salen del mismo fichero que alimenta la ficha de Play.** Una sola fuente de
+verdad, sin dos changelogs que se desincronicen. Hoy sólo existe `default.txt`, que Fastlane
+usa como comodín para cualquier `versionCode`; el diseño lo respeta como fallback, y a
+partir de la próxima versión basta con añadir `3.txt` para que Play y GitHub cuenten lo
+mismo. No hace falta renombrar nada ahora.
+
+### 3. Ajuste de disparadores y coste del CI
+
+Medido sobre un run completo de la Fase 0:
+
+| Paso | Tiempo |
+|---|---|
+| Lint | 3m 51s |
+| Tests | 43s |
+| Build debug | 2m 15s |
+| Build release bundle | 4m 38s |
+| **Total** | **~11m 30s** |
+
+Dos problemas:
+
+- **Trabajo duplicado.** Con `push: [main, 'chore/**']` y `pull_request: [main]`, cada push
+  a una rama con PR abierta dispara el workflow dos veces sobre el mismo commit: 23 minutos
+  de runner para 11 de información. Se introdujo al arreglar el disparador en la Fase 0.
+- **`bundleRelease` es el paso más caro** —más que el lint— y sólo importa antes de
+  publicar. Correrlo en cada PR de un contribuidor es coste sin retorno.
+
+Disparadores nuevos:
+
+```yaml
+on:
+  push:
+    branches: [ main ]
+    tags: [ 'v*' ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+```
+
+Y `bundleRelease` condicionado:
+
+```yaml
+      - name: Build release bundle
+        if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
+        run: ./gradlew bundleRelease
+```
+
+Resultado: las PRs bajan a ~7 minutos, las ramas dejan de duplicar trabajo —reciben CI a
+través de su PR—, y nada llega a una release sin pasar por R8, porque las releases salen de
+tags y el tag ejecuta el paso.
+
+**No se elimina ningún paso.** `assembleDebug` cuesta 2m 15s y no es redundante con
+`bundleRelease`: cubre las dependencias `debugImplementation` (el `compose.ui.tooling` de
+tres módulos), el merge de manifiestos y recursos de debug y el empaquetado. Además es el
+comando que ejecuta cualquier contribuidor en su máquina y el que documenta `CLAUDE.md`; si
+se rompe, se rompe justo para quien intente colaborar.
+
+Se valoró paralelizar en dos jobs —wall-clock del más lento en vez de la suma, y en repo
+público los minutos son gratis— pero cada job repaga el setup y pierde el estado incremental
+de Gradle. Para este tamaño de proyecto, el `if` da mejor relación coste/complejidad.
+
+### 4. Badges e instalación en el README
+
+El README tiene hoy cinco badges tecnológicos (Android, Kotlin, Compose, Material Design 3,
+MIT) y **ninguno que lleve a instalar la app ni que indique en qué versión va**. Se añaden:
+
+- Badge de Google Play enlazando a la ficha de la app.
+- Badge de última release, que se actualiza solo contra la API de GitHub.
+- Badge de estado del CI.
+
+Y el enlace de instalación sube por encima del pliegue, junto al feature graphic, en vez de
+quedar accesible sólo desde la homepage del autor.
+
+## Criterio de terminación
+
+1. Existe el tag `v1.1.0` en `4bc32a2`, con su Release creada a mano, y no existe `v1.0.0`.
+2. Empujar un tag `v*` desde un commit posterior a esta fase crea una Release cuyo cuerpo
+   contiene el texto del changelog de Fastlane, y sólo la crea si el job de build pasó.
+3. Un push a una rama con PR abierta dispara el workflow **una sola vez**.
+4. `bundleRelease` no se ejecuta en PRs, y sí en `main` y en tags.
+5. El job `build` conserva `permissions: contents: read`.
+6. El README muestra los badges de Play Store, última release y CI, y el enlace de
+   instalación está por encima del pliegue.


### PR DESCRIPTION
## Phase 1 — Releases and discoverability

Ambio had no tags, no releases, no issues and no stars. The original roadmap put contribution paperwork first, but with zero audience there are no contributors whose barrier to lower — and something more basic was missing: a visitor could not tell which version the project was on, or reach the app from the repo. This phase fixes that, and cuts the CI's wasted work in half along the way.

The contribution paperwork (`CONTRIBUTING.md`, issue/PR templates, `CODE_OF_CONDUCT.md`) is deliberately left for a follow-up, once the project can actually be found and followed.

### What changed

| | Before | After |
|---|---|---|
| Tags | none | `v1.1.0` |
| Releases | none | 1, and future ones publish themselves |
| Release notes source | — | the Fastlane changelog that already feeds Play |
| CI runs per push with an open PR | 2 | 1 |
| PR feedback time | ~11m 30s | ~7m |
| `bundleRelease` | every PR | `main` and tags only |
| Install / version badges | none | Play Store, latest release, CI |

### Releases publish themselves

A `release` job was added to `ci.yml`, gated on `startsWith(github.ref, 'refs/tags/v')` and — importantly — on `needs: build`. Chaining it to the build job is what guarantees no release can exist without lint, tests, `assembleDebug` and `bundleRelease` having passed first. In a separate workflow the two would fire in parallel on the same tag, and a release could publish while the build was failing.

Permissions are scoped per job: `build` keeps `contents: read`, only `release` gets `contents: write`.

Notes come from `fastlane/metadata/android/en-US/changelogs/`, keyed by `versionCode` with `default.txt` as fallback. That is the same file Fastlane uploads to the Play listing, so the two cannot drift.

**This was verified end-to-end**, not just structurally: a disposable `v0.0.1-ci-test` tag was pushed, both jobs ran green, `bundleRelease` executed (rather than being skipped, as it correctly is on PRs), and the generated release body contained the Fastlane changelog followed by GitHub's auto-generated changes. The tag and release were then deleted.

### No APKs attached, and why

The project uses Play App Signing and the maintainer does not want signing keys in GitHub Actions. Together those rule out publishing APKs: without a key in CI there is nothing to sign with, and a debug-signed artifact proves nothing since anyone can produce that signature. Beyond that, with Play App Signing the APK users receive is signed by Google with a key the project does not hold — so any APK published here would carry a different signature, and two APKs with different signatures cannot update each other. Someone installing from GitHub would be stranded in a separate install lineage and would have to uninstall, losing their data, to move to the Play version.

Attaching the Google-signed universal APK that Play Console exposes in the App Bundle Explorer *would* preserve upgrade compatibility, but it needs a manual step on every release. This phase stayed with what is fully automatable. F-Droid remains the path to a no-manual-step install channel, and is still slated for Phase 4.

### CI cost

Measured on a complete Phase 0 run: Lint 3m51s, Tests 43s, Build debug 2m15s, **Build release bundle 4m38s** — the most expensive step, more than lint, and one that only matters before publishing.

Two fixes. `chore/**` left the `push` trigger, so a push to a branch with an open PR no longer runs the workflow twice over the same commit (23 minutes of runner for 11 minutes of information — a regression introduced when the trigger was fixed in Phase 0). And `bundleRelease` is now conditional on `main` or a tag.

`assembleDebug` was kept. It is not redundant with `bundleRelease`: it covers the `debugImplementation` dependencies, debug manifest and resource merging, and packaging — and it is the command a contributor runs locally and that `CLAUDE.md` documents. If it breaks, it breaks for whoever is trying to help.

### `v1.1.0` was tagged by hand

The tag points at `4bc32a2` ("chore: release 1.1.0"). Its release was created manually rather than by the new automation, because GitHub runs workflows from the tagged commit and `.github/workflows/ci.yml` did not exist yet at that point in history — it was created in Phase 0. Every future tag comes from a commit that has it, and publishes itself.

`v1.0.0` was deliberately not created: that version existed in the code but never shipped to Play, so tagging it would invent a release that never happened.

### README

Two rows of badges: the actionable ones on top (install, current version, build status), the informational ones below. The install link now sits above the fold instead of being reachable only through the author's homepage. All four URLs were checked for a 200 before committing — a broken badge on the front page is worse than no badge.

Two claims Phase 0 had invalidated were also corrected: the Kotlin badge said 2.0 (now 2.3.21) and the build commands said 75 unit tests (now 154).
